### PR TITLE
Add script to parse ICS files from Google Calendar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development, :test do
   gem 'pry-byebug', '~> 3.3'
   gem 'rspec-rails', '~> 3.5'
   gem 'rubocop', '~> 0.46'
+  gem 'icalendar'
 end
 
 group :development do

--- a/scripts/parse-ics.rb
+++ b/scripts/parse-ics.rb
@@ -1,0 +1,27 @@
+require 'icalendar'
+
+PATH = "< path/to/ics/file/here >"
+
+cal_file = File.open(PATH)
+
+cals = Icalendar::Calendar.parse(cal_file)
+
+cal_file.close
+
+cal = cals.first
+
+events = []
+
+cal.events.each_with_index { |event, i|
+  events[i] = {
+    start_time: event.dtstart.to_date,
+    end_time: event.dtend.to_date,
+    stamp_time: event.dtstamp.to_date,
+    created_at: event.created.to_date,
+    last_modified: event.last_modified.to_date,
+    name: event.summary.to_s,
+    calendar: cal.x_wr_cal_name
+  }
+}
+
+puts events.last


### PR DESCRIPTION
This script creates a Ruby object from the .ics file specified as
the `PATH` constant. At the moment it only prints one of the parsed
events to the terminal. TODO: figure out how to get this stuff into
the database.

This commit also adds the icalendar gem to Gemfile.