### PR TITLE
Improve ICS parsing script

### DIFF
--- a/scripts/parse-ics.rb
+++ b/scripts/parse-ics.rb
@@ -1,27 +1,65 @@
 require 'icalendar'
 
-PATH = "< path/to/ics/file/here >"
+PATH = "< your/path/here >"
 
+# Open the file and call icalendar parse method on it
 cal_file = File.open(PATH)
-
 cals = Icalendar::Calendar.parse(cal_file)
-
 cal_file.close
 
+# ICS files can have multiple calendars, but ours don't,
+# so we select only the first calendar
 cal = cals.first
 
 events = []
 
-cal.events.each_with_index { |event, i|
-  events[i] = {
-    start_time: event.dtstart.to_date,
-    end_time: event.dtend.to_date,
-    stamp_time: event.dtstamp.to_date,
-    created_at: event.created.to_date,
-    last_modified: event.last_modified.to_date,
-    name: event.summary.to_s,
-    calendar: cal.x_wr_cal_name
-  }
-}
+cal.events.each do |e|
+  material = {}
 
-puts events.last
+  # remove anything inside parenthesis, in our case
+  # parens tell us who the material is assigned to
+  name = e.summary.gsub(/\(.*\)/, '')
+  # remove all whitespace from name
+  name = name.gsub(/\s/, '')
+
+  # materials are all lower case, if the name has uppercase
+  # letters we dont want it.
+  # We also don't want worktime events
+  unless /[A-Z]/ =~ name || /worktime/ =~ name
+    unique = true
+
+    # Check for duplicates
+    events.each do |event|
+      if event[:name] === name
+        unique = false
+      end
+    end
+
+    # Set "type" property by looking for the type in
+    # the name of the material
+    if /project/ =~ name
+      material[:type] = "project"
+    elsif /diagnostic/ =~ name
+      material[:type] = "diagnostic"
+    elsif /study/ =~ name
+      material[:type] = "study"
+    elsif /practice/ =~ name
+      material[:type] = "practice"
+    elsif /challenge/ =~ name
+      material[:type] = "challenge"
+    else
+      material[:type] = "talk"
+    end
+
+    material[:name] = name
+
+    # length is the estimated time to deliver the material in minutes
+    material[:length] = ((e.dtend.to_time - e.dtstart.to_time) / 60).to_i
+
+    if unique
+      events.push(material)
+    end
+  end
+end
+
+puts events


### PR DESCRIPTION
The script now returns an array of Ruby hashes with properties :name,
:type, and :length for each material. It filters out anything with
uppercase letters, because we name materials in snake case. It removes
whitespace and assignments in parenthesis. Length is a fixnum
representing estimated time in minutes. It also checks for duplicate
materials.